### PR TITLE
Refactor handler to accept zerolog.Logger instead of context

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -9,19 +9,18 @@ import (
 	"slices"
 
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Handler is the bridge between slog and zerolog
 type Handler struct {
 	slog.Handler
-	ctx context.Context
+	logger *zerolog.Logger
 }
 
 // New creates a new slog handler, storing the stored context in the handler struct.
 // This context should contain a zerolog.Logger that will be used by the handler
-func New(ctx context.Context) Handler {
-	return Handler{ctx: ctx}
+func New(logger *zerolog.Logger) Handler {
+	return Handler{logger: logger}
 }
 
 // Enabled checks to see if the zerolog global log level is allowed based on the incoming slog.Level
@@ -48,7 +47,7 @@ func (s Handler) Enabled(_ context.Context, level slog.Level) bool {
 // Handle handles the the slog.Record into a zerolog.Event and sends it using the logger
 // that's stored in the context that was set when the handler was initialised
 func (s Handler) Handle(ctx context.Context, r slog.Record) error {
-	event := log.Ctx(s.ctx).
+	event := s.logger.
 		WithLevel(slogToZlogLevel(r.Level)).
 		Ctx(ctx)
 

--- a/slogzlog_example_test.go
+++ b/slogzlog_example_test.go
@@ -2,7 +2,6 @@ package slogzlog
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -19,24 +18,21 @@ func ExampleNew() {
 	// panic levels, these will effectively disable the slogzlog bridge
 	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 
-	// Create a new zerolog.Logger and store it in a context. This logger also
-	// outputs to a buffer for testing.
+	// Create a new zerolog.Logger
 	buf := new(bytes.Buffer)
-	ctx := log.
+	zedLogger := log.
 		Output(
 			io.MultiWriter(
 				zerolog.ConsoleWriter{Out: buf, NoColor: true},
 			),
-		).
-		WithContext(context.Background())
+		)
 
-	// Create the slogzlog handler with the previously created logger. The context
-	// containing the logger will be stored in the handler
-	handler := New(ctx)
+	// Create the slogzlog handler with the previously created logger
+	handler := New(&zedLogger)
 
 	// Use the handler as desired
 	logger := slog.New(handler)
-	logger.ErrorContext(ctx, "an error occurred",
+	logger.Error("an error occurred",
 		slog.Any("error", fmt.Errorf("something bad happened")),
 		slog.Duration("time_to_error", time.Millisecond*125),
 	)


### PR DESCRIPTION
Update handler, tests, and examples to pass a *zerolog.Logger directly rather than storing it in a context. Simplify logger setup and usage throughout the codebase.